### PR TITLE
Multi-qubit Taget Gates and SWAP Gate

### DIFF
--- a/src/main/scala/scotty/quantum/Labeled.scala
+++ b/src/main/scala/scotty/quantum/Labeled.scala
@@ -3,5 +3,5 @@ package scotty.quantum
 trait Labeled {
   val label: Option[String]
 
-  def hasLabel(l: String): Boolean = label.contains(l)
+  def hasLabel(l: String): Boolean = label.isDefined && label.get == l
 }

--- a/src/main/scala/scotty/quantum/Labeled.scala
+++ b/src/main/scala/scotty/quantum/Labeled.scala
@@ -1,0 +1,7 @@
+package scotty.quantum
+
+trait Labeled {
+  val label: Option[String]
+
+  def hasLabel(l: String): Boolean = label.contains(l)
+}

--- a/src/main/scala/scotty/quantum/Op.scala
+++ b/src/main/scala/scotty/quantum/Op.scala
@@ -21,8 +21,9 @@ sealed trait Gate extends Op {
   def isUnitary(implicit ctx: QuantumContext): Boolean = ctx.isUnitary(this)
 
   def matrix(implicit ctx: QuantumContext): Matrix = this match {
-    case target: Target => targetMatrix.getOrElse(ctx.targetMatrix(target))
+    case swap: QubitSwap => ctx.swapMatrix(swap)
     case control: Control => ctx.controlMatrix(control)
+    case target: Target => targetMatrix.getOrElse(ctx.targetMatrix(target))
   }
 
   def targetMatrix: Option[Matrix] = None
@@ -33,10 +34,10 @@ sealed trait Gate extends Op {
 }
 
 trait Target extends Gate {
-  val index: Int
+  val index1: Int
 
   val params = Seq[Double]()
-  val indexes = Seq(index)
+  val indexes = Seq(index1)
 }
 
 trait Control extends Gate {
@@ -48,7 +49,13 @@ trait Control extends Gate {
     case t: Target => t
     case c: Control => c.finalTarget
   }
-  lazy val finalTargetIndex = finalTarget.index
-  lazy val controlIndexes = indexes.filter(i => i != finalTargetIndex)
+  lazy val targetIndexes = finalTarget.indexes
+  lazy val controlIndexes = indexes.filter(!targetIndexes.contains(_))
   lazy val isAsc = controlIndex < target.indexes(0)
+}
+
+trait QubitSwap extends Target {
+  val index2: Int
+
+  override val indexes = Seq(index1, index2)
 }

--- a/src/main/scala/scotty/quantum/Op.scala
+++ b/src/main/scala/scotty/quantum/Op.scala
@@ -36,10 +36,12 @@ sealed trait Gate extends Op {
 trait Target extends Gate {
   val index1: Int
 
-  val params = Seq[Double]()
-  val indexes = Seq(index1)
+  lazy val params = Seq[Double]()
+  lazy val indexes = Seq(index1)
 
-  def isReversed: Boolean = false
+  def indexesAreAsc: Boolean = indexes.length <= 1 || (indexes, indexes.tail).zipped.forall(_ <= _)
+
+  require(indexesAreAsc, "Qubit indexes have to be ascending.")
 }
 
 trait Control extends Gate {
@@ -59,7 +61,5 @@ trait Control extends Gate {
 trait QubitSwap extends Target {
   val index2: Int
 
-  override val indexes = Seq(index1, index2)
-
-  override def isReversed: Boolean = index1 > index2
+  override lazy val indexes = if (index1 > index2) Seq(index2, index1) else Seq(index1, index2)
 }

--- a/src/main/scala/scotty/quantum/Op.scala
+++ b/src/main/scala/scotty/quantum/Op.scala
@@ -38,6 +38,8 @@ trait Target extends Gate {
 
   val params = Seq[Double]()
   val indexes = Seq(index1)
+
+  def isReversed: Boolean = false
 }
 
 trait Control extends Gate {
@@ -58,4 +60,6 @@ trait QubitSwap extends Target {
   val index2: Int
 
   override val indexes = Seq(index1, index2)
+
+  override def isReversed: Boolean = index1 > index2
 }

--- a/src/main/scala/scotty/quantum/QuantumContext.scala
+++ b/src/main/scala/scotty/quantum/QuantumContext.scala
@@ -8,6 +8,8 @@ trait QuantumContext {
 
   def controlMatrix(gate: Control): Matrix
 
+  def swapMatrix(gate: QubitSwap): Matrix
+
   def par(gate1: Gate, gate2: Gate): Matrix
 
   def isUnitary(gate: Gate): Boolean
@@ -40,6 +42,8 @@ object QuantumContext {
     def fiftyFifty: Qubit = this(Complex(1 / Math.sqrt(2.0)), Complex(1 / Math.sqrt(2.0)))
 
     def areAmplitudesValid(q: Qubit): Boolean = MathUtils.isProbabilityValid(q.a.abs, q.b.abs)
+
+    def apply(as: Array[Complex]): Qubit = this(as(0), as(1))
   }
 
   sealed trait Register[T] {

--- a/src/main/scala/scotty/quantum/StandardGate.scala
+++ b/src/main/scala/scotty/quantum/StandardGate.scala
@@ -3,25 +3,25 @@ package scotty.quantum
 object StandardGate {
   case class Controlled(controlIndex: Int, target: Gate) extends Control
 
-  case class H(index: Int) extends Target
+  case class H(index1: Int) extends Target
 
-  case class I(index: Int) extends Target
+  case class I(index1: Int) extends Target
 
-  case class X(index: Int) extends Target
+  case class X(index1: Int) extends Target
 
-  case class Y(index: Int) extends Target
+  case class Y(index1: Int) extends Target
 
-  case class Z(index: Int) extends Target
+  case class Z(index1: Int) extends Target
 
-  case class RX(theta: Double, index: Int) extends Target {
+  case class RX(theta: Double, index1: Int) extends Target {
     override val params = Seq(theta)
   }
 
-  case class RY(theta: Double, index: Int) extends Target {
+  case class RY(theta: Double, index1: Int) extends Target {
     override val params = Seq(theta)
   }
 
-  case class RZ(theta: Double, index: Int) extends Target {
+  case class RZ(theta: Double, index1: Int) extends Target {
     override val params = Seq(theta)
   }
 
@@ -32,4 +32,6 @@ object StandardGate {
   case class CCNOT(controlIndex: Int, controlIndex2: Int, targetIndex: Int) extends Control {
     val target = Controlled(controlIndex2, X(targetIndex))
   }
+
+  case class SWAP(index1: Int, index2: Int) extends QubitSwap
 }

--- a/src/main/scala/scotty/quantum/StandardGate.scala
+++ b/src/main/scala/scotty/quantum/StandardGate.scala
@@ -14,15 +14,15 @@ object StandardGate {
   case class Z(index1: Int) extends Target
 
   case class RX(theta: Double, index1: Int) extends Target {
-    override val params = Seq(theta)
+    override lazy val params = Seq(theta)
   }
 
   case class RY(theta: Double, index1: Int) extends Target {
-    override val params = Seq(theta)
+    override lazy val params = Seq(theta)
   }
 
   case class RZ(theta: Double, index1: Int) extends Target {
-    override val params = Seq(theta)
+    override lazy val params = Seq(theta)
   }
 
   case class CNOT(controlIndex: Int, targetIndex: Int) extends Control {

--- a/src/main/scala/scotty/quantum/math/MathUtils.scala
+++ b/src/main/scala/scotty/quantum/math/MathUtils.scala
@@ -1,5 +1,7 @@
 package scotty.quantum.math
 
+import scotty.quantum.QuantumContext.QuantumException
+
 import scala.annotation.tailrec
 
 object MathUtils {
@@ -17,6 +19,11 @@ object MathUtils {
 
   implicit class IntHelpers(i: Int) {
     def toBinary: Seq[Int] = toBinaryImpl(i)
+
+    def toBasisState: Array[Complex] =
+      if (i == 1) Array(Complex(0), Complex(1))
+      else if (i == 0) Array(Complex(1), Complex(0))
+      else throw QuantumException("Only classical 1s and 0s can be converted to quantum basis state.")
   }
 
   implicit class ComplexHelpers(c: Complex) {

--- a/src/main/scala/scotty/simulator/SimSuperposition.scala
+++ b/src/main/scala/scotty/simulator/SimSuperposition.scala
@@ -9,8 +9,8 @@ import scotty.quantum.math.Complex
 
 import scala.util.Random
 
-case class SimSuperposition(vector: Vector)
-                           (implicit random: Random) extends Superposition with VectorTransformations {
+case class SimSuperposition(vector: Vector, label: Option[String] = None)
+                           (implicit random: Random) extends Superposition with VectorTransformations with Labeled {
   val rawVector = vector
 
   def par(state: Superposition): SimSuperposition = {

--- a/src/main/scala/scotty/simulator/math/Implicits.scala
+++ b/src/main/scala/scotty/simulator/math/Implicits.scala
@@ -4,11 +4,13 @@ import scotty.quantum.math.Complex
 import org.apache.commons.math3.complex.{Complex => ApacheComplex}
 
 object Implicits {
-  implicit def toApacheComplexNestedArray(ca: Array[Array[Complex]]) = ca.map(c => c.map(r => new ApacheComplex(r.r, r.i)))
+  implicit def toApacheComplexNestedArray(ca: Array[Array[Complex]]) =
+    ca.map(c => c.map(r => new ApacheComplex(r.r, r.i)))
   implicit def toApacheComplexArray(ca: Array[Complex]) = ca.map(c => new ApacheComplex(c.r, c.i))
   implicit def toApacheComplex(c: Complex) = new ApacheComplex(c.r, c.i)
 
-  implicit def toComplexNestedArray(ca: Array[Array[ApacheComplex]]) = ca.map(c => c.map(r => Complex(r.getReal, r.getImaginary)))
+  implicit def toComplexNestedArray(ca: Array[Array[ApacheComplex]]) =
+    ca.map(c => c.map(r => Complex(r.getReal, r.getImaginary)))
   implicit def toComplexArray(ca: Array[ApacheComplex]) = ca.map(c => Complex(c.getReal, c.getImaginary))
   implicit def toComplex(c: ApacheComplex) = Complex(c.getReal, c.getImaginary)
 }

--- a/src/main/scala/scotty/simulator/math/RawGate.scala
+++ b/src/main/scala/scotty/simulator/math/RawGate.scala
@@ -7,7 +7,7 @@ import scotty.simulator.math.LinearAlgebra.MatrixTransformations
 case class RawGate(rawMatrix: Matrix) extends Target with MatrixTransformations {
   // Exact qubit indexes don't matter in this context because we only use this gate
   // for arbitrary matrix calculations.
-  val index = -1
+  val index1 = -1
 
   override lazy val qubitCount = Math.sqrt(rawMatrix.length).toInt
 

--- a/src/test/scala/simulator/ControlledGateSpec.scala
+++ b/src/test/scala/simulator/ControlledGateSpec.scala
@@ -29,4 +29,24 @@ class ControlledGateSpec extends FlatSpec {
     assert(sim.runAndMeasure(Circuit(X(4), X(2), Controlled(4, Controlled(2, X(0))))).toBinaryRegister ==
       BinaryRegister(1, 0, 1, 0, 1))
   }
+
+  it should "work with a two-qubit SWAP gate" in {
+    assert(sim.runAndMeasure(Circuit(X(0), X(1), Controlled(0, SWAP(1, 2)))).toBinaryRegister == BinaryRegister(1, 0, 1))
+  }
+
+  it should "work with a two-qubit SWAP gate with a gap" in {
+    assert(sim.runAndMeasure(Circuit(X(0), X(1), Controlled(0, SWAP(1, 3)))).toBinaryRegister == BinaryRegister(1, 0, 0, 1))
+  }
+
+  it should "work with a two-qubit reversed SWAP gate with a gap" in {
+    assert(sim.runAndMeasure(Circuit(X(0), X(3), Controlled(0, SWAP(3, 1)))).toBinaryRegister == BinaryRegister(1, 1, 0, 0))
+  }
+
+  it should "work with a two-qubit SWAP gate while being part of the gap" in {
+    assert(sim.runAndMeasure(Circuit(X(2), X(4), Controlled(2, SWAP(1, 4)))).toBinaryRegister == BinaryRegister(0, 1, 1, 0, 0))
+  }
+
+  it should "work with a two-qubit reversed SWAP gate while being part of the gap" in {
+    assert(sim.runAndMeasure(Circuit(X(2), X(4), Controlled(2, SWAP(4, 1)))).toBinaryRegister == BinaryRegister(0, 1, 1, 0, 0))
+  }
 }

--- a/src/test/scala/simulator/CustomGatesSpec.scala
+++ b/src/test/scala/simulator/CustomGatesSpec.scala
@@ -10,7 +10,7 @@ class CustomGatesSpec extends FlatSpec {
   val sim = QuantumSimulator()
 
   "Custom gate" should "negate a qubit" in {
-    case class CustomGate(index: Int) extends Target {
+    case class CustomGate(index1: Int) extends Target {
       override def targetMatrix = Some(Array(
         Array(Complex(0), Complex(1)),
         Array(Complex(1), Complex(0))

--- a/src/test/scala/simulator/StandardGatesSpec.scala
+++ b/src/test/scala/simulator/StandardGatesSpec.scala
@@ -94,4 +94,42 @@ class StandardGatesSpec extends FlatSpec {
         assert(StateProbabilityReader(s).read(1).amplitude == Complex(0, 0))
     }
   }
+
+  "SWAP" should "swap two nearby qubits 1 and 0" in {
+    assert(sim.runAndMeasure(Circuit(X(0), SWAP(0, 1))).toBinaryRegister == BinaryRegister(0, 1))
+  }
+
+  it should "swap two nearby qubits 0 and 1" in {
+    assert(sim.runAndMeasure(Circuit(X(1), SWAP(0, 1))).toBinaryRegister == BinaryRegister(1, 0))
+  }
+
+  it should "swap two qubits with a gap of 1 qubit" in {
+    assert(sim.runAndMeasure(Circuit(X(0), SWAP(0, 2))).toBinaryRegister == BinaryRegister(0, 0, 1))
+  }
+
+  it should "swap two qubits with a gap of 2 qubits" in {
+    assert(sim.runAndMeasure(Circuit(X(0), X(2), SWAP(0, 3))).toBinaryRegister == BinaryRegister(0, 0, 1, 1))
+  }
+
+  it should "swap two qubits in reverse with a gap of 2 qubits" in {
+    assert(sim.runAndMeasure(Circuit(X(3), X(2), SWAP(3, 0))).toBinaryRegister == BinaryRegister(1, 0, 1, 0))
+  }
+
+  it should "have correct amplitudes" in {
+    sim.run(Circuit(H(0), SWAP(0, 1))) match {
+      case s: Superposition =>
+        assert(StateProbabilityReader(s).read(0).amplitude.rounded == Complex(fiftyPercent, 0))
+        assert(StateProbabilityReader(s).read(1).amplitude.rounded == Complex(fiftyPercent, 0))
+        assert(StateProbabilityReader(s).read(2).amplitude.rounded == Complex(0, 0))
+        assert(StateProbabilityReader(s).read(3).amplitude.rounded == Complex(0, 0))
+    }
+
+    sim.run(Circuit(H(1), SWAP(0, 1))) match {
+      case s: Superposition =>
+        assert(StateProbabilityReader(s).read(0).amplitude.rounded == Complex(fiftyPercent, 0))
+        assert(StateProbabilityReader(s).read(1).amplitude.rounded == Complex(0, 0))
+        assert(StateProbabilityReader(s).read(2).amplitude.rounded == Complex(fiftyPercent, 0))
+        assert(StateProbabilityReader(s).read(3).amplitude.rounded == Complex(0, 0))
+    }
+  }
 }


### PR DESCRIPTION
## Changes

- Support for `Target` gates that can act on any number of qubits.
- Add `Swapped` trait and a `SWAP` standard gate.
- Add `Labeled` trait for labeling quantum primitives.
- Simplify and optimize `QuantumSimulator.controlMatrix`.
---
Closes #5